### PR TITLE
🩹 tormate-config.php: Use .example TLD

### DIFF
--- a/tormate-config.php
+++ b/tormate-config.php
@@ -54,7 +54,7 @@ define ("MAX_FILE_SIZE", 5 * 1024 * 1024);
  *
  * undefined by default
  */
-//define ("PROXY", "some.server.org:8888")
+//define ("PROXY", "some.server.example:8888")
 
 
 /* secret that clients need to provide to use the gate


### PR DESCRIPTION
… in order to make it absolutely obvious that it's just a placeholder.